### PR TITLE
Corrige teste

### DIFF
--- a/bee_1113/test_bee_1113.c
+++ b/bee_1113/test_bee_1113.c
@@ -5,17 +5,17 @@ void setUp(){};
 
 void tearDown(){};
 
-void test_function_check_bigger()
+void test_function_check_increasing()
 {
-  TEST_ASSERT_FALSE(check_bigger(13, 22));
-  TEST_ASSERT_TRUE(check_bigger(25, 22));
-  TEST_ASSERT_EQUAL(0, check_bigger(0, 0));
-  TEST_ASSERT_EQUAL(0, check_bigger(5, 5));
+  TEST_ASSERT_FALSE(check_increasing(13, 22));
+  TEST_ASSERT_TRUE(check_increasing(25, 22));
+  TEST_ASSERT_EQUAL(0, check_increasing(0, 0));
+  TEST_ASSERT_EQUAL(0, check_increasing(5, 5));
 }
 
 int main(void)
 {
   UNITY_BEGIN();
-  RUN_TEST(test_function_check_bigger);
+  RUN_TEST(test_function_check_increasing);
   return UNITY_END();
 }


### PR DESCRIPTION
O arquivo test_bee_1113.c chama a função check_bigger várias vezes, mas em bee_1113.h só existe a função check_increasing. Fiz uma pequena correção para que test_bee_1113.c chame check_increasing ao invés de check_bigger.